### PR TITLE
Add node images with click expansion

### DIFF
--- a/data/sample.json
+++ b/data/sample.json
@@ -7,6 +7,7 @@
       "layer": "Signal",
       "category": "Environment",
       "description": "Node 1"
+      ,"image_url": "https://via.placeholder.com/150"
     },
     {
       "id": "Af-1",
@@ -14,6 +15,7 @@
       "layer": "Signal",
       "category": "Social",
       "description": "Node 2"
+      ,"image_url": "https://via.placeholder.com/150"
     },
     {
       "id": "Im-1",
@@ -21,6 +23,7 @@
       "layer": "Scenario",
       "category": "Social",
       "description": "Node 3"
+      ,"image_url": "https://via.placeholder.com/150"
     },
     {
       "id": "Go-1",
@@ -28,6 +31,7 @@
       "layer": "Paradigm",
       "category": "N/A",
       "description": "Node 4"
+      ,"image_url": "https://via.placeholder.com/150"
     }
   ],
   "links": [

--- a/style.css
+++ b/style.css
@@ -46,3 +46,8 @@ svg text {
 .node text.description {
   fill: #333;
 }
+
+/* ノード画像のスタイル */
+.node image {
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- enable optional `image_url` per node
- render images clipped to circles when provided
- expand circles and show their images on click
- support pointer-event-less images
- add sample dataset images

## Testing
- `node -v`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687ddc46b0f48331b461fa188a120d53