### PR TITLE
Improve node click behavior

### DIFF
--- a/style.css
+++ b/style.css
@@ -47,6 +47,12 @@ svg text {
   fill: #333;
 }
 
+/* 説明文背景 */
+.node rect.description-bg {
+  fill: rgba(255, 255, 255, 0.8);
+  pointer-events: none;
+}
+
 /* ノード画像のスタイル */
 .node image {
   pointer-events: none;


### PR DESCRIPTION
## Summary
- keep node labels visible when expanded
- wrap descriptions to 1.5× the expanded circle width
- add semi-transparent white background behind description

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e2d90c6bc8331ba1e80af355b189e